### PR TITLE
Add support for NSS trust stores under linux

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,2 @@
-{:deps {org.clojure/tools.cli {:mvn/version "1.0.194"}}}
+{:deps {org.clojure/tools.cli {:mvn/version "1.0.194"}}
+ :aliases {:main {:main-opts ["-m" "certifiable.main"]}}}

--- a/src/certifiable/nss_trust.clj
+++ b/src/certifiable/nss_trust.clj
@@ -5,8 +5,6 @@
             [clojure.java.shell :as shell :refer [sh]])
   (:import [java.io File]))
 
-;; currently this only works on OSX
-
 (defmulti firefox-profile-dir identity)
 
 (defmethod firefox-profile-dir :default [_]
@@ -14,6 +12,17 @@
 
 (defmethod firefox-profile-dir :macos [_]
   (io/file (System/getProperty "user.home") "Library/Application Support/Firefox/Profiles"))
+
+(defmethod firefox-profile-dir :linux [_]
+  (io/file (System/getProperty "user.home") ".mozilla/firefox"))
+
+(defmulti chromium-profile-dir identity)
+
+(defmethod chromium-profile-dir :default [_]
+  nil)
+
+(defmethod chromium-profile-dir :linux [_]
+  (io/file (System/getProperty "user.home") "snap/chromium"))
 
 (defn firefox-profiles []
   (when-let [dir ^File (firefox-profile-dir (util/os?))]
@@ -23,11 +32,26 @@
                #(.isDirectory ^File %)
                (.listFiles dir))))))
 
+(defn nss-shared-db []
+  (io/file (System/getProperty "user.home") ".pki/nssdb"))
+
+(defn chromium-profiles []
+  (when-let [dir ^File (chromium-profile-dir (util/os?))]
+    (and (.exists dir)
+         (->> (.listFiles dir)
+              (map #(io/file % ".pki/nssdb"))
+              (filter #(.isDirectory ^File %))))))
+
 (defn prefix-profile-path [profile-path]
   (cond
     (.exists (io/file profile-path "cert9.db")) (str "sql:" profile-path)
     (.exists (io/file profile-path "cert8.db")) (str "dbm:" profile-path)
     :else nil))
+
+(defn cert-db-paths []
+  (keep prefix-profile-path (concat (firefox-profiles)
+                                    (chromium-profiles)
+                                    [(nss-shared-db)])))
 
 (def certutil-path
   (memoize
@@ -48,9 +72,13 @@
         dname (subs (.getName (.getIssuerDN cert)) 3)]
     (str dname " " (.getSerialNumber cert))))
 
+(def command-log (atom []))
+
 (defn certutil-cmd [& args]
   (when (certutil-installed?)
-    (apply sh (certutil-path) args)))
+    (let [res (apply sh (certutil-path) args)]
+      (swap! command-log conj (assoc res :cmd args))
+      res)))
 
 (defn cert-valid-cmd [prefixed-profile-path uniq-name]
   (certutil-cmd "-V" "-d" prefixed-profile-path "-u" "L" "-n" uniq-name))
@@ -64,38 +92,43 @@
 
 (defn has-cert? [pem-path]
   (let [uniq-name (ca-uniq-name pem-path)]
-    (->> (keep prefix-profile-path (firefox-profiles))
+    (->> (cert-db-paths)
          (map #(cert-valid-cmd % uniq-name))
          (map :exit)
          (some zero?))))
 
 (defn add-cert [pem-path]
   (let [uniq-name (ca-uniq-name pem-path)]
-    (->> (keep prefix-profile-path (firefox-profiles))
-         (mapv #(cert-add-cmd % uniq-name pem-path))
+    (->> (cert-db-paths)
+         (mapv #(and (cert-add-cmd % uniq-name pem-path) %))
          not-empty)))
 
 (defn remove-cert [pem-path]
   (let [uniq-name (ca-uniq-name pem-path)]
-    (->> (keep prefix-profile-path (firefox-profiles))
+    (->> (cert-db-paths)
          (mapv #(cert-delete-cmd % uniq-name)))))
 
 (defn install-trust! [pem-path]
-  (when (= :macos (util/os?))
-    (log/info "Attempting to add root certificate to Firefox nss trust store.")
+  (when (#{:macos :linux} (util/os?))
+    (log/info "Attempting to add root certificate to browsers' nss trust store.")
     (if-not (certutil-path)
       (do
         (log/info "Warning \"certutil\" command is not available so this certificate will not be installed for Firefox")
         (log/info "Please install \"certutil\" with \"brew install nss\""))
       (let [uniq-name (pr-str (ca-uniq-name pem-path))]
         (if (has-cert? pem-path)
-          (do (log/info "Cert" uniq-name "already present in Firefox trust store.")
+          (do (log/info "Cert" uniq-name "already present in browsers' trust store.")
               true)
-          (if (add-cert pem-path)
-            (do (log/info "Cert" uniq-name "successfully added to Firefox trust store!")
-                true)
-            ;; TODO add output from certutil to inform why it failed?
+          (if-let [profiles (add-cert pem-path)]
             (do
+              (doseq [profile profiles]
+                (log/info "Cert" uniq-name "successfully added to browser trust store " profile))
+              true)
+            (do
+              (doseq [{:keys [cmd out err]} @command-log]
+                (apply println "$" cmd)
+                (println out)
+                (println err))
               (log/info "FAILED adding" uniq-name "to Firefox trust store!")
               (log/info "Add the certifcate manually"))))))))
 


### PR DESCRIPTION
Firefox profiles are under ~/.mozilla/firefox

Chrome/Chromium uses ~/.pki/nssdb , or profile-specific
~/snap/chromium/<profile-id>/.pki/nssdb.

This will install the cert in every profile it finds. It also saves the output
of certutil, which gets printed out in case something goes wrong.

I hope you don't mind the extra bits (the `:main` alias in deps.edn and the storing of certutil output), I can remove those if you prefer.